### PR TITLE
Keep a reference to the gurobi lib to avoid GC

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -10,7 +10,7 @@ if not ghome then
    print("gurobi.torch: init.lua: Error: GUROBI_HOME environment variable not defined.")
    os.exit(-1)
 end
-ffi.load(paths.concat(ghome, "lib", "libgurobi65.so"), true)
+M.gurobi_lib = ffi.load(paths.concat(ghome, "lib", "libgurobi65.so"), true)
 ffi.cdef [[
 typedef void GRBenv;
 typedef void GRBmodel;

--- a/test.lua
+++ b/test.lua
@@ -5,6 +5,9 @@ torch.setdefaulttensortype('torch.DoubleTensor')
 
 local gurobi = require 'gurobi'
 
+collectgarbage()
+collectgarbage()
+
 local tester = torch.Tester()
 local gurobiTest = torch.TestSuite()
 


### PR DESCRIPTION
Additionnally, manually trigger GC in the test to verify that the problem doesn't happen.

I haven't tested exactly this (I have some additional local changes to point to Gurobi 7 instead of 6.5) but it fixes the issue for me and should do the same with 6.5.